### PR TITLE
Add tests, prefer update-state! over set-state!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ resources/public/js
 .idea/
 target/
 figwheel_server.log
+.lein-repl-history
+.nrepl-port
+cljs-kurssi.iml
+out/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 resources/public/js
+.idea/
+target/
+figwheel_server.log

--- a/src/cljs/widgetshop/app/products.cljs
+++ b/src/cljs/widgetshop/app/products.cljs
@@ -3,8 +3,8 @@
   (:require [widgetshop.app.state :as state]
             [widgetshop.server :as server]))
 
-(defn- products-by-category [app category products-by-category]
-  (assoc-in app [:products-by-category category] products-by-category))
+(defn- products-by-category [app category products]
+  (assoc-in app [:products-by-category category] products))
 
 (defn- set-categories [app categories]
   (assoc-in app [:categories] categories))

--- a/src/cljs/widgetshop/app/products.cljs
+++ b/src/cljs/widgetshop/app/products.cljs
@@ -1,17 +1,28 @@
 (ns widgetshop.app.products
   "Controls product listing information."
-  (:require [widgetshop.app.state :refer [update-state! set-state!]]
+  (:require [widgetshop.app.state :as state]
             [widgetshop.server :as server]))
 
+(defn- products-by-category [app category products-by-category]
+  (assoc-in app [:products-by-category category] products-by-category))
+
+(defn- set-categories [app categories]
+  (assoc-in app [:categories] categories))
+
+(defn- load-products-by-category! [{:keys [categories] :as app} server-get-fn! category-id]
+  (let [category (some #(when (= (:id %) category-id) %) categories)]
+    (server-get-fn! category)
+    (-> app
+        (assoc :category category)
+        (assoc-in [:products-by-category category] :loading))))
+
 (defn select-category-by-id! [category-id]
-  (update-state!
-   (fn [{:keys [categories] :as app}]
-     (let [category (some #(when (= (:id %) category-id) %) categories)]
-       (server/get! (str "/products/" (:id category))
-                    {:on-success #(set-state! [:products-by-category category] %)})
-       (-> app
-           (assoc :category category)
-           (assoc-in [:products-by-category category] :loading))))))
+  (state/update-state!
+    load-products-by-category!
+    (fn [category]
+      (server/get! (str "/products/" (:id category))
+                   {:on-success #(state/update-state! products-by-category category %)}))
+    category-id))
 
 (defn load-product-categories! []
-  (server/get! "/categories" {:on-success #(set-state! [:categories] %)}))
+  (server/get! "/categories" {:on-success #(state/update-state! set-categories %)}))

--- a/src/cljs/widgetshop/app/state.cljs
+++ b/src/cljs/widgetshop/app/state.cljs
@@ -21,11 +21,3 @@
   (swap! app
          (fn [current-app-state]
            (apply update-fn current-app-state args))))
-
-(defn set-state!
-  "Updates the application state using a path and a value.
-
-  NOTE: It's better to use update-state! for better testability, since you can easily
-  write unit tests for the function you provide to update-state!"
-  [path value]
-  (swap! app assoc-in path value))

--- a/src/cljs/widgetshop/app/state.cljs
+++ b/src/cljs/widgetshop/app/state.cljs
@@ -9,10 +9,23 @@
                       ;; Loaded product listings keyd by selected category
                       :products-by-category {}}))
 
-(defn update-state! [update-fn & args]
+(defn update-state!
+  "Updates the application state using a function, that accepts as parameters
+  the current state and a variable number of arguments, and returns a new state.
+
+  (defn set-foo [app n]
+     (assoc app :foo n))
+
+  (update-state! set-foo 1)"
+  [update-fn & args]
   (swap! app
          (fn [current-app-state]
            (apply update-fn current-app-state args))))
 
-(defn set-state! [path value]
+(defn set-state!
+  "Updates the application state using a path and a value.
+
+  NOTE: It's better to use update-state! for better testability, since you can easily
+  write unit tests for the function you provide to update-state!"
+  [path value]
   (swap! app assoc-in path value))

--- a/src/cljs/widgetshop/main.cljs
+++ b/src/cljs/widgetshop/main.cljs
@@ -5,7 +5,7 @@
             [cljs-react-material-ui.core :refer [get-mui-theme color]]
             [cljs-react-material-ui.reagent :as ui]
             [cljs-react-material-ui.icons :as ic]
-            [widgetshop.app.state :refer [app]]
+            [widgetshop.app.state :as state]
             [widgetshop.app.products :as products]))
 
 
@@ -73,7 +73,7 @@
 
 
 (defn main-component []
-  [widgetshop @app])
+  [widgetshop @state/app])
 
 (defn ^:export main []
   (products/load-product-categories!)

--- a/test/clj/widgetshop/example_test.clj
+++ b/test/clj/widgetshop/example_test.clj
@@ -1,0 +1,5 @@
+(ns widgetshop.example-test
+  (:require [clojure.test :refer :all]))
+
+(deftest foobar
+  (is (= 1 1)))

--- a/test/cljs/widgetshop/app/products_test.cljs
+++ b/test/cljs/widgetshop/app/products_test.cljs
@@ -1,0 +1,27 @@
+(ns widgetshop.app.products-test
+  (:require [cljs.test :as test :refer-macros [deftest is testing]]
+            [widgetshop.app.products :as p]))
+
+(deftest products-by-category
+  (testing "Value is set to the right path"
+    (is (= (p/products-by-category {} :foo [1 2 3])
+           {:products-by-category {:foo [1 2 3]}}))))
+
+(deftest setting-categories
+  (is (= (p/set-categories {:bar :baz} {:foo [] :baz []})
+         {:categories {:foo [] :baz []}
+          :bar :baz})))
+
+(deftest loading-products-by-category
+  (is (= (p/load-products-by-category!
+           {:categories [{:id 2 :name :foo}
+                         {:id 1 :name :bar}]}
+           (constantly "whatever doesn't matter")
+           1)
+         {:category {:id 1 :name :bar}
+          :categories [{:id 2 :name :foo}
+                       {:id 1 :name :bar}]
+          :products-by-category {{:id 1 :name :bar} :loading}})))
+
+
+

--- a/test/cljs/widgetshop/test_runner.cljs
+++ b/test/cljs/widgetshop/test_runner.cljs
@@ -1,0 +1,7 @@
+(ns widgetshop.test-runner
+  (:require [doo.runner :refer-macros [doo-tests]]
+            [widgetshop.app.products-test]))
+
+(enable-console-print!)
+
+(doo-tests 'widgetshop.app.products-test)


### PR DESCRIPTION
I feel like these changes could be included in the "template".

I added tests, and made use of the `update-state!` function instead of the `set-state!` one. Using update-state! results in code that you can more easily write unit tests for, and I think we should encourage beginners to think more in the terms of `state -> state` functions, and not guide them towards the `set-state!` function, which is inherently impure.