### PR TITLE
Fix warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject cljs-kurssi "0.1-SNAPSHOT"
   :dependencies [[org.clojure/clojure "1.9.0-alpha19"]
-                 [org.clojure/clojurescript "1.9.660"]
+                 [org.clojure/clojurescript "1.9.946"]
 
                  ;; Component library
                  [com.stuartsierra/component "0.3.2"]

--- a/src/cljs/widgetshop/main.cljs
+++ b/src/cljs/widgetshop/main.cljs
@@ -16,11 +16,6 @@
 ;; Task 2: Add actions to add item to cart. See that cart badge is automatically updated.
 ;;
 
-(defn listaus [e! jutut]
-  [:ul
-   (for [juttu jutut]
-     [:li [:a {:on-click #(e! (->ValitseJuttu juttu))} juttu]])])
-
 (defn widgetshop [app]
   [ui/mui-theme-provider
    {:mui-theme (get-mui-theme


### PR DESCRIPTION
Figwheel was not giving warnings about using undeclared thingies, which caused a lot of frustration. Updating ClojureScript fixed this. Also there was this unused function that referenced undeclared stuff which resulted in warnings after figwheel started giving them.