### PR TITLE
Update figwheel

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -35,7 +35,7 @@
                  [cljsjs/react "15.6.1-1"]
                  [cljsjs/react-dom "15.6.1-1"]
                  [cljs-react-material-ui "0.2.48"]
-                 [figwheel "0.5.10"]
+                 [figwheel "0.5.14"]
 
                  ;; Something pulls an old guava which prevents closure compiler
                  ;; override here
@@ -43,7 +43,7 @@
                  ]
 
   :plugins [[lein-cljsbuild "1.1.5"]
-            [lein-figwheel "0.5.10"]]
+            [lein-figwheel "0.5.14"]]
 
   ;; Sources for backend: clj and cljc (shared with frontend)
   :source-paths ["src/clj" "src/cljc"]


### PR DESCRIPTION
Changes made to code would not appear in browser without reload and I was getting following errors when figwheel was loading changes to browser:

ioc_helpers.cljs?rel=1510678737639:42 Uncaught TypeError: goog.net.jsloader.load is not a function
    at figwheel$client$file_reloading$reload_file_in_html_env (file_reloading.cljs?rel=1510678742544:219)
    at figwheel$client$file_reloading$reload_file (file_reloading.cljs?rel=1510678742544:261)
    at figwheel$client$file_reloading$blocking_load (file_reloading.cljs?rel=1510678742544:280)
    at file_reloading.cljs?rel=1510678742544:290
    at file_reloading.cljs?rel=1510678742544:288
    at figwheel$client$file_reloading$state_machine__34842__auto____1 (file_reloading.cljs?rel=1510678742544:288)
    at figwheel$client$file_reloading$state_machine__34842__auto__ (file_reloading.cljs?rel=1510678742544:288)
    at cljs$core$async$impl$ioc_helpers$run_state_machine (ioc_helpers.cljs?rel=1510678737639:35)
    at cljs$core$async$impl$ioc_helpers$run_state_machine_wrapped (ioc_helpers.cljs?rel=1510678737639:39)
    at ioc_helpers.cljs?rel=1510678737639:48

Updating figwheel fixed this and changes are updated to browser as they should now.